### PR TITLE
fix request date type to be symetric

### DIFF
--- a/src/it/k8s/test.yaml
+++ b/src/it/k8s/test.yaml
@@ -51,6 +51,9 @@ paths:
                   type: string
                 secret:
                   type: string
+                date:
+                  type: string
+                  format: date
                 params:
                   $ref: '#/components/schemas/UniqueEventRequest'
             encoding:

--- a/src/main/java/cd/connect/openapi/DartV3ApiGenerator.java
+++ b/src/main/java/cd/connect/openapi/DartV3ApiGenerator.java
@@ -169,6 +169,7 @@ public class DartV3ApiGenerator extends DartClientCodegen implements CodegenConf
           cm.vendorExtensions.put("dartClassName", org.openapitools.codegen.utils.StringUtils.camelize(cm.getClassname()));
           if (cm.vars != null) {
             cm.vars.forEach(cp -> {
+              cp.vendorExtensions.put("generateNullValuesToJson", Boolean.parseBoolean((String) additionalProperties.get("generateNullValuesToJson")));
               if (cp.items != null && cp.items.allowableValues != null && cp.items.allowableValues.get("enumVars") != null) {
                 cp.items.enumName = cp.items.complexType;
               }

--- a/src/main/resources/dart2-v3template/class.mustache
+++ b/src/main/resources/dart2-v3template/class.mustache
@@ -232,7 +232,9 @@ class {{classname}}{{#parent}} extends {{parent}}{{/parent}} {
       {{/isDate}}
       {{/isDateTime}}
         {{^isNullable}}
-    }
+    } {{#vendorExtensions.generateNullValuesToJson}}else {
+          json[r'{{baseName}}'] = null;
+    }{{/vendorExtensions.generateNullValuesToJson}}
         {{/isNullable}}
       {{/vendorExtensions.x-dart-inherited}}
     {{/vars}}

--- a/src/main/resources/dart2-v3template/class.mustache
+++ b/src/main/resources/dart2-v3template/class.mustache
@@ -207,7 +207,9 @@ class {{classname}}{{#parent}} extends {{parent}}{{/parent}} {
       json[r'{{baseName}}'] = {{name}}.toUtc().toIso8601String();
       {{/isDateTime}}
       {{#isDate}}
-      json[r'{{baseName}}'] = {{name}}.toUtc().toIso8601String();
+      {{=<% %>=}}
+      json[r'<%baseName%>'] = "${<%name%>.year.toString()}-${<%name%>.month.toString().padLeft(2,'0')}-${<%name%>.day.toString().padLeft(2,'0')}";
+      <%={{ }}=%>
       {{/isDate}}
       {{^isDateTime}}
       {{^isDate}}

--- a/src/test/resources/test.yaml
+++ b/src/test/resources/test.yaml
@@ -51,6 +51,9 @@ paths:
                   type: string
                 secret:
                   type: string
+                date:
+                  type: string
+                  format: date
                 params:
                   $ref: '#/components/schemas/UniqueEventRequest'
             encoding:


### PR DESCRIPTION
The  Date type not handled well on request. The Date type does not contain any time information (as in request side) so the posted format cannot contain it.