### PR TITLE
Add additional property to convert vendor extension

### DIFF
--- a/src/main/java/cd/connect/openapi/DartV3ApiGenerator.java
+++ b/src/main/java/cd/connect/openapi/DartV3ApiGenerator.java
@@ -213,6 +213,7 @@ public class DartV3ApiGenerator extends DartClientCodegen implements CodegenConf
           if (cm.vars != null) {
             cm.vars.forEach(cp -> {
               CodegenProperty correctingSettings = cp;
+              cp.vendorExtensions.put("generateNullValuesToJson", Boolean.parseBoolean((String) additionalProperties.get("generateNullValuesToJson")));
 
               while (correctingSettings != null) {
                 correctInternals(cm, correctingSettings);


### PR DESCRIPTION
There is an additional parameter to activate extension which enables to send null values in payload.