### PR TITLE
Add fix (?) for Enum reference name

### DIFF
--- a/src/main/resources/dart2-v3template/class.mustache
+++ b/src/main/resources/dart2-v3template/class.mustache
@@ -8,7 +8,7 @@ class {{classname}}{{#parent}} extends {{parent}}{{/parent}} {
     {{/allowableValues}}
     {{#allowableValues}}
       {{#isEnum}}
-        {{{datatypeWithEnum}}} {{{name}}}{{#defaultValue}} = {{{defaultValue}}}{{/defaultValue}};
+        {{{dataType}}} {{{name}}}{{#defaultValue}} = {{{defaultValue}}}{{/defaultValue}};
       {{/isEnum}}
       {{^isEnum}}
         {{^complexType}}


### PR DESCRIPTION
There are some problem with the naming of enumeration. It causes not compilable codes, with this fix the code is working, but I'm not sure that it is not causing problems in other cases. It is based that in other part of the template the enun using the data 'dataType' instead of 'datatypeWithEnum'. As I see the enum handling moved from template to helper, so I guess it can be OK, but I'm not 100% sure. @rvowles can you check it please?