### PR TITLE
List<AnyOf<*>> support

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -305,3 +305,13 @@ behind as you generate.
       </plugin>
 ----
 
+=== Testing
+
+To test locally you can run tests by invoking this command:
+
+[source,bash]
+----
+mvn -Dmaven.wagon.http.retryHandler.count=5 --batch-mode verify
+----
+
+The source for the tests is located in src/k8s** folders. The generated test output will be in target/it/k8s**.

--- a/src/it/k8s/pom.xml
+++ b/src/it/k8s/pom.xml
@@ -86,6 +86,9 @@
                 <additionalProperty>
                   pubspec-dev-dependencies=uuid: 2.0.4
                 </additionalProperty>
+                <additionalProperty>
+                  listAnyOf=true
+                </additionalProperty>
               </additionalProperties>
               <globalProperties>
                 <skipFormModel>false</skipFormModel>

--- a/src/it/k8s/test.yaml
+++ b/src/it/k8s/test.yaml
@@ -404,5 +404,40 @@ components:
             - square
             - logarithmic
       uniqueItems: false
-
+    fruit_basket:
+      title: fruit
+      type: object
+      required:
+        - owner
+      properties:
+        owner:
+          type: string
+        fruits:
+          items:
+            # https://swagger.io/docs/specification/data-models/inheritance-and-polymorphism/
+            anyOf:
+              - $ref: '#/components/schemas/my_apple'
+              - $ref: '#/components/schemas/my_banana'
+            discriminator:
+              propertyName: type
+              mapping:
+                banana: '#/components/schemas/my_banana'
+                apple: '#/components/schemas/my_apple'
+          type: array
+    my_apple:
+      title: apple
+      type: object
+      properties:
+        type:
+          type: string
+        kind:
+          type: string
+    my_banana:
+      title: banana
+      type: object
+      properties:
+        type:
+          type: string
+        count:
+          type: number
 

--- a/src/it/k8s/test/api_tests.dart
+++ b/src/it/k8s/test/api_tests.dart
@@ -1,3 +1,5 @@
+import 'dart:convert';
+
 import 'package:k8s_api/api.dart';
 import 'package:test/test.dart';
 
@@ -35,15 +37,15 @@ main() {
   // it wouldn't change the hash
   test(
       'hashing an object which has two fields of the same type is still different',
-          () {
-        var ht = HashTest()
-          ..fieldOne = false
-          ..fieldTwo = true;
-        var ht1 = HashTest()
-          ..fieldOne = true
-          ..fieldTwo = false;
-        expect(false, ht.hashCode == ht1.hashCode);
-      });
+      () {
+    var ht = HashTest()
+      ..fieldOne = false
+      ..fieldTwo = true;
+    var ht1 = HashTest()
+      ..fieldOne = true
+      ..fieldTwo = false;
+    expect(false, ht.hashCode == ht1.hashCode);
+  });
 
   test('additional properties mappings', () {
     const addProp = {
@@ -96,6 +98,34 @@ main() {
           ..title = 'Scully'
           ..img = 'img'
           ..imageUrl = 'http://blah');
-    expect(ap.mapWithEnums['statuses'], [EventStatus.STREAMING, EventStatus.CLOSED]);
+    expect(ap.mapWithEnums['statuses'],
+        [EventStatus.STREAMING, EventStatus.CLOSED]);
+  });
+
+  test("List<AnyOf<MyApple,MyBanana>> - parsing json array with discriminator",
+      () {
+    final items =
+        AnyOfMyAppleMyBanana.listFromJson(jsonDecode(_dummyDiscriminatorJson));
+
+    expect(items, hasLength(2));
+    expect(items[0].discriminator, AnyOfDiscriminatorMyAppleMyBanana.MyApple);
+    expect(items[0].asMyApple().type, "apple");
+    expect(items[0].asMyApple().kind, "Foxwhelp");
+    expect(items[1].discriminator, AnyOfDiscriminatorMyAppleMyBanana.MyBanana);
+    expect(items[1].asMyBanana().type, "banana");
+    expect(items[1].asMyBanana().count, 42);
   });
 }
+
+const _dummyDiscriminatorJson = r"""
+[
+  {
+    "type": "apple",
+    "kind": "Foxwhelp"
+  },
+  {
+    "type": "banana",
+    "count": 42
+  }
+]
+""";

--- a/src/it/k8s_null/pom.xml
+++ b/src/it/k8s_null/pom.xml
@@ -92,6 +92,9 @@
                 <additionalProperty>
                   nullSafe-array-default=true
                 </additionalProperty>
+                <additionalProperty>
+                  listAnyOf=true
+                </additionalProperty>
               </additionalProperties>
               <globalProperties>
                 <skipFormModel>false</skipFormModel>

--- a/src/it/k8s_null/test.yaml
+++ b/src/it/k8s_null/test.yaml
@@ -404,5 +404,40 @@ components:
             - square
             - logarithmic
       uniqueItems: false
-
+    fruit_basket:
+      title: fruit
+      type: object
+      required:
+        - owner
+      properties:
+        owner:
+          type: string
+        fruits:
+          items:
+            # https://swagger.io/docs/specification/data-models/inheritance-and-polymorphism/
+            anyOf:
+              - $ref: '#/components/schemas/my_apple'
+              - $ref: '#/components/schemas/my_banana'
+            discriminator:
+              propertyName: type
+              mapping:
+                banana: '#/components/schemas/my_banana'
+                apple: '#/components/schemas/my_apple'
+          type: array
+    my_apple:
+      title: apple
+      type: object
+      properties:
+        type:
+          type: string
+        kind:
+          type: string
+    my_banana:
+      title: banana
+      type: object
+      properties:
+        type:
+          type: string
+        count:
+          type: number
 

--- a/src/it/k8s_null/test/api_tests.dart
+++ b/src/it/k8s_null/test/api_tests.dart
@@ -1,3 +1,5 @@
+import 'dart:convert';
+
 import 'package:k8s_api/api.dart';
 import 'package:test/test.dart';
 
@@ -35,15 +37,15 @@ main() {
   // it wouldn't change the hash
   test(
       'hashing an object which has two fields of the same type is still different',
-          () {
-        var ht = HashTest()
-          ..fieldOne = false
-          ..fieldTwo = true;
-        var ht1 = HashTest()
-          ..fieldOne = true
-          ..fieldTwo = false;
-        expect(false, ht.hashCode == ht1.hashCode);
-      });
+      () {
+    var ht = HashTest()
+      ..fieldOne = false
+      ..fieldTwo = true;
+    var ht1 = HashTest()
+      ..fieldOne = true
+      ..fieldTwo = false;
+    expect(false, ht.hashCode == ht1.hashCode);
+  });
 
   test('additional properties mappings', () {
     const addProp = {
@@ -99,4 +101,31 @@ main() {
     expect(ap.mapWithEnums?['statuses'],
         [EventStatus.STREAMING, EventStatus.CLOSED]);
   });
+
+  test("List<AnyOf<MyApple,MyBanana>> - parsing json array with discriminator",
+      () {
+    final items =
+        AnyOfMyAppleMyBanana.listFromJson(jsonDecode(_dummyDiscriminatorJson));
+
+    expect(items, hasLength(2));
+    expect(items[0].discriminator, AnyOfDiscriminatorMyAppleMyBanana.MyApple);
+    expect(items[0].asMyApple().type, "apple");
+    expect(items[0].asMyApple().kind, "Foxwhelp");
+    expect(items[1].discriminator, AnyOfDiscriminatorMyAppleMyBanana.MyBanana);
+    expect(items[1].asMyBanana().type, "banana");
+    expect(items[1].asMyBanana().count, 42);
+  });
 }
+
+const _dummyDiscriminatorJson = r"""
+[
+  {
+    "type": "apple",
+    "kind": "Foxwhelp"
+  },
+  {
+    "type": "banana",
+    "count": 42
+  }
+]
+""";

--- a/src/main/resources/dart2-v3template/_any_of_class.mustache
+++ b/src/main/resources/dart2-v3template/_any_of_class.mustache
@@ -1,0 +1,107 @@
+class {{classname}} {
+  {{classname}}();
+
+  {{#nullSafe}}late {{/nullSafe}}dynamic _value;
+  dynamic get value => _value;
+  void set value(dynamic v) {
+    {{#innerTypes}}
+    if (v is {{classname}}) {
+      _value = v;
+      _discriminator = {{enumClassname}}.{{classname}};
+      return;
+    }
+    {{/innerTypes}}
+    throw ArgumentError("${v.runtimeType} cannot be a value of AnyOf<{{anyOfTemplate}}>");
+  }
+
+  {{#nullSafe}}late {{/nullSafe}}{{enumClassname}} _discriminator;
+  {{enumClassname}} get discriminator => _discriminator;
+
+  @override
+  String toString() {
+    return 'AnyOf<{{anyOfTemplate}}>[value=$_value]';
+  }
+
+  fromJson(Map<String, dynamic>{{#nullSafe}}?{{/nullSafe}} json) {
+    if (json == null) return;
+
+    final discriminatorStr = json[r'{{discriminatorProperty}}'];
+
+    if (discriminatorStr == null) {
+      return;
+    }
+
+    switch (discriminatorStr) {
+      {{#innerTypes}}
+      case r'{{discriminatorValue}}':
+        _value = {{classname}}.fromJson(json);
+        _discriminator = {{enumClassname}}.{{classname}};
+        break;
+      {{/innerTypes}}
+    }
+  }
+
+  {{classname}}.fromJson(Map<String, dynamic>{{#nullSafe}}?{{/nullSafe}} json) {
+    fromJson(json); // allows child classes to call
+  }
+
+  Map<String, dynamic> toJson() => LocalApiClient.serialize(_value);
+
+  @override
+  bool operator ==(Object other) {
+    if (identical(this, other)) {
+      return true;
+    }
+
+    if (other is {{classname}} && runtimeType == other.runtimeType) {
+      return _value == other._value;
+    }
+
+    return false;
+  }
+
+  @override
+  int get hashCode {
+    var hashCode = runtimeType.hashCode;
+
+    if (_value != null) {
+      hashCode = hashCode * 31 + _value.hashCode;
+    }
+
+    {{#nullSafe}}hashCode = hashCode * 31 + _discriminator.hashCode;{{/nullSafe}}
+    {{^nullSafe}}
+    if (_discriminator != null) {
+      hashCode = hashCode * 31 + _discriminator.hashCode;
+    }
+    {{/nullSafe}}
+
+    return hashCode;
+  }
+
+  {{classname}} copyWith() {
+    final copy = {{classname}}();
+    copy._value = _value.copyWith();
+    copy._discriminator = _discriminator;
+    return copy;
+  }
+
+  static List<{{classname}}> listFromJson(List<dynamic>{{#nullSafe}}?{{/nullSafe}} json) {
+    return json == null ? <{{classname}}>[] : json.map((value) => {{classname}}.fromJson(value)).toList();
+  }
+
+  {{#innerTypes}}{{classname}} as{{classname}}() => _value as {{classname}};
+  {{/innerTypes}}
+
+  dynamic as({{enumClassname}} type) {
+    switch (type) {
+      {{#innerTypes}}
+      case {{enumClassname}}.{{classname}}:
+        return _value as {{classname}};
+      {{/innerTypes}}
+    }
+  }
+}
+
+enum {{enumClassname}} {
+  {{#innerTypes}}{{classname}},{{/innerTypes}}
+}

--- a/src/main/resources/dart2-v3template/apilib.mustache
+++ b/src/main/resources/dart2-v3template/apilib.mustache
@@ -24,3 +24,7 @@ part 'api_client.dart';
 {{#x-dart-parts}}
 part '{{{.}}}';
 {{/x-dart-parts}}
+
+{{#x-dart-anyparts}}
+part '{{{.}}}';
+{{/x-dart-anyparts}}

--- a/src/main/resources/dart2-v3template/model.mustache
+++ b/src/main/resources/dart2-v3template/model.mustache
@@ -13,3 +13,7 @@ part of {{pubName}}.api;
 {{/isEnum}}
 {{/model}}
 {{/models}}
+
+{{#isAnyOfClass}}
+{{>_any_of_class}}
+{{/isAnyOfClass}}

--- a/src/test/java/cd/connect/openapi/SampleRunner.java
+++ b/src/test/java/cd/connect/openapi/SampleRunner.java
@@ -1,9 +1,11 @@
 package cd.connect.openapi;
 
-import io.swagger.v3.oas.models.OpenAPI;
 import org.junit.Test;
 import org.openapitools.codegen.OpenAPIGenerator;
 
+import java.io.BufferedReader;
+import java.io.IOException;
+import java.io.InputStreamReader;
 import java.util.Arrays;
 
 public class SampleRunner {
@@ -22,8 +24,50 @@ public class SampleRunner {
       "--global-property", "skipFormModel=false",
       "--additional-properties", "nullSafe=true",
       "--additional-properties", "nullSafe-array-default=true",
+      "--additional-properties", "listAnyOf=true",
       "--output", "target/" + getClass().getSimpleName())
       .toArray(new String[0]));
+  }
+
+  @Test
+  public void runGeneratorWithListAnyOfNNBD() {
+    // given
+    String schemaLocation = getClass().getResource("/list_any_of_test.yml").getFile();
+    String outputFolder = "target/" + getClass().getSimpleName()+"_list_any_of_test_NNBD";
+
+    // when
+    OpenAPIGenerator.main(Arrays.asList("generate",
+      "--input-spec", schemaLocation,
+      "--generator-name", "dart2-api",
+      "--additional-properties", "pubName=sample_app",
+      "--additional-properties", "nullSafe=true",
+      "--additional-properties", "nullSafe-array-default=true",
+      "--additional-properties", "listAnyOf=true",
+      "--output", outputFolder)
+      .toArray(new String[0]));
+
+    // then
+    verifyIsDartPackage(outputFolder);
+  }
+
+  @Test
+  public void runGeneratorWithListAnyOfNoNullSafety() {
+    // given
+    String schemaLocation = getClass().getResource("/list_any_of_test.yml").getFile();
+    String outputFolder = "target/" + getClass().getSimpleName()+"_list_any_of_test_no_null_safety";
+
+    // when
+    OpenAPIGenerator.main(Arrays.asList("generate",
+      "--input-spec", schemaLocation,
+      "--generator-name", "dart2-api",
+      "--additional-properties", "pubName=sample_app",
+      // "--additional-properties", "nullSafe=false", // passing anything turns null safety on
+      "--additional-properties", "listAnyOf=true",
+      "--output", outputFolder)
+      .toArray(new String[0]));
+
+    // then
+    verifyIsDartPackage(outputFolder);
   }
 
 //  @Test
@@ -74,4 +118,31 @@ public class SampleRunner {
 //      "--output", "/Users/richard/projects/fh/featurehub/admin-frontend/app_mr_layer")
 //      .toArray(new String[0]));
 //  }
+
+  private static void verifyIsDartPackage(String libFolder) {
+    String verifyScriptLocation = SampleRunner.class.getResource("/verify_package.sh").getFile();
+    int value = execute("sh -e " + verifyScriptLocation + " " + libFolder);
+    assert (value == 0);
+  }
+
+  private static int execute(String cmd)  {
+    try {
+      Runtime rt = Runtime.getRuntime();
+      Process pr = rt.exec(cmd);
+      new Thread(() -> {
+        BufferedReader input = new BufferedReader(new InputStreamReader(pr.getInputStream()));
+        String line;
+
+        try {
+          while ((line = input.readLine()) != null)
+            System.out.println(line);
+        } catch (IOException e) {
+          e.printStackTrace();
+        }
+      }).start();
+      return pr.waitFor();
+    } catch (Throwable t) {
+      return -1;
+    }
+  }
 }

--- a/src/test/resources/list_any_of_test.yml
+++ b/src/test/resources/list_any_of_test.yml
@@ -1,0 +1,53 @@
+---
+openapi: 3.0.1
+info:
+  title: fruity
+  version: 0.0.1
+paths:
+  "/":
+    get:
+      responses:
+        '200':
+          description: desc
+          content:
+            application/json:
+              schema:
+                "$ref": "#/components/schemas/fruit_basket"
+components:
+  schemas:
+    fruit_basket:
+      title: fruit
+      type: object
+      required:
+        - owner
+      properties:
+        owner:
+          type: string
+        fruits:
+          items:
+            # https://swagger.io/docs/specification/data-models/inheritance-and-polymorphism/
+            anyOf:
+              - $ref: '#/components/schemas/my_apple'
+              - $ref: '#/components/schemas/my_banana'
+            discriminator:
+              propertyName: type
+              mapping:
+                banana: '#/components/schemas/my_banana'
+                apple: '#/components/schemas/my_apple'
+          type: array
+    my_apple:
+      title: apple
+      type: object
+      properties:
+        type:
+          type: string
+        kind:
+          type: string
+    my_banana:
+      title: banana
+      type: object
+      properties:
+        type:
+          type: string
+        count:
+          type: number

--- a/src/test/resources/verify_package.sh
+++ b/src/test/resources/verify_package.sh
@@ -1,0 +1,11 @@
+#!/usr/bin/env bash
+# $1 -> you are supposed to pass relative path to where the generated package is
+
+# fail if any commands fails
+set -e
+# debug log
+set -x
+
+cd "$1"
+pub get
+dartanalyzer lib


### PR DESCRIPTION
Resolves #25 

I have no deep knowledge of this codebase and this PR is pretty much a result of poking around different parts of the ApiGenerator.

Essentially my hacking starts with a method called `toAnyOfName`. This method seems to be triggered for every __List<AnyOf>__ and before mustache files are rendered. This is where I intercept __anyOf__ occurrences and store this data for later in `extraAnyParts` and `extraAnyClasses` fields. Then I use these fields to populate mustache files.

I got something working so I'm happy as it solves my issue. Unsure though if maintainers are happy with the quality of my code 😅

# Checklist

- [x] Add enum to class and include in the hash - should be also be useful for this:

```
switch(myValue.discriminator) {
  case AnyOfAB.A:
  case AnyOfAB.B:
}
```
- [x] Added value setter (useful when writing tests that involve AnyOf generated classes)
- [x] Added list_any_of.yaml test scenario to `SampleRunner`
- [x] keeping _value as non-nullable, if the value is supposed to be nullable, it should be `AnyOfClass?`
- [x] integration tests (verify package from `SampleRunner`)
- [x] Check if our internal generated API package doesn't get broken ( 🍯 https://github.com/vishna/dart-openapi-maven/releases/tag/openapi-dart-generator-5.3-anyOf.1 )
