### PR TITLE
Pass octet stream data straight out without decoding

### DIFF
--- a/src/it/k8s/test.yaml
+++ b/src/it/k8s/test.yaml
@@ -34,6 +34,26 @@ paths:
             application/json:
               schema:
                 $ref: "#/components/schemas/EventResponse"
+  /event/kivan/{id}:
+    get:
+      parameters:
+        - name: id
+          in: path
+          required: true
+          schema:
+            type: string
+      tags:
+        - ControlService
+      description: "testing application/octet-stream"
+      operationId: getOctetStream
+      responses:
+        200:
+          description: "content is octet-stream"
+          content:
+            application/octet-stream:
+              schema:
+                type: string
+                format: binary
   /event/getstatus:
     post:
       tags:

--- a/src/it/k8s_null/test.yaml
+++ b/src/it/k8s_null/test.yaml
@@ -34,6 +34,26 @@ paths:
             application/json:
               schema:
                 $ref: "#/components/schemas/EventResponse"
+  /event/kivan/{id}:
+    get:
+      parameters:
+        - name: id
+          in: path
+          required: true
+          schema:
+            type: string
+      tags:
+        - ControlService
+      description: "testing application/octet-stream"
+      operationId: getOctetStream
+      responses:
+        200:
+          description: "content is octet-stream"
+          content:
+            application/octet-stream:
+              schema:
+                type: string
+                format: binary
   /event/getstatus:
     post:
       tags:

--- a/src/main/java/cd/connect/openapi/DartV3ApiGenerator.java
+++ b/src/main/java/cd/connect/openapi/DartV3ApiGenerator.java
@@ -26,6 +26,7 @@ public class DartV3ApiGenerator extends DartClientCodegen implements CodegenConf
   private static final Logger log = LoggerFactory.getLogger(DartV3ApiGenerator.class);
   private static final String LIBRARY_NAME = "dart2-api";
   private static final String DART2_TEMPLATE_FOLDER = "dart2-v3template";
+  private static final String API_PRODUCES_RAW_STREAM = "vendorExtensions.x-dart-produces-raw";
   private static final String ARRAYS_WITH_DEFAULT_VALUES_ARE_NULLSAFE = "nullSafe-array-default";
   protected boolean arraysThatHaveADefaultAreNullSafe;
   protected boolean isNullSafeEnabled;
@@ -58,6 +59,8 @@ public class DartV3ApiGenerator extends DartClientCodegen implements CodegenConf
     // replace Object with dynamic
     this.typeMapping.put("object", "dynamic");
     this.typeMapping.put("AnyType", "dynamic");
+    this.typeMapping.put("file", "ApiResponse");
+    this.typeMapping.put("binary", "ApiResponse");
 
     // override the location
     embeddedTemplateDir = templateDir = DART2_TEMPLATE_FOLDER;
@@ -189,10 +192,6 @@ public class DartV3ApiGenerator extends DartClientCodegen implements CodegenConf
     if ("dynamic".equals(cp.complexType)) {
       cp.isAnyType = true;
       cp.isPrimitiveType = true;
-    }
-
-    if ("dependencies".equals(cp.name)) {
-      System.out.println("");
     }
 
     if (cp.allowableValues != null && cp.allowableValues.get("enumVars") != null) {
@@ -446,6 +445,8 @@ public class DartV3ApiGenerator extends DartClientCodegen implements CodegenConf
       extensions.put(prefix + "xml", "application/xml");
     } else if (lowerCaseContentTypes.contains("application/yaml")) {
       extensions.put(prefix + "yaml", "application/yaml");
+    } else if (lowerCaseContentTypes.contains("application/octet-stream")) {
+      extensions.put(prefix + "raw", "application/octet-stream");
     } else {
       extensions.put(prefix + "json", "application/json"); // fallback
     }

--- a/src/main/resources/dart2-v3template/api.mustache
+++ b/src/main/resources/dart2-v3template/api.mustache
@@ -18,7 +18,12 @@ part of {{pubName}}.api;
       {{#returnType}}Future<{{{returnType}}}> {{/returnType}}{{^returnType}}Future<void> {{/returnType}}
     {{/vendorExtensions.x-dart-produces-json}}
     {{^vendorExtensions.x-dart-produces-json}}
+      {{#vendorExtensions.x-dart-produces-raw}}
+      {{#returnType}}Future<{{{returnType}}}> {{/returnType}}{{^returnType}}Future<void> {{/returnType}}
+      {{/vendorExtensions.x-dart-produces-raw}}
+      {{^vendorExtensions.x-dart-produces-raw}}
       {{#returnType}}Future<String> {{/returnType}}{{^returnType}}Future<void> {{/returnType}}
+      {{/vendorExtensions.x-dart-produces-raw}}
     {{/vendorExtensions.x-dart-produces-json}}
     {{nickname}}({{#allParams}}{{#required}}{{{dataType}}} {{paramName}}{{^-last}}, {{/-last}}{{/required}}{{/allParams}}{{#hasOptionalParams}}{Options{{#nullSafe}}?{{/nullSafe}} options{{#hasParams}}, {{/hasParams}}{{#allParams}}{{^required}}{{{dataType}}}{{#nullSafe}}?{{/nullSafe}} {{paramName}}{{^-last}}, {{/-last}}{{/required}}{{/allParams}} }{{/hasOptionalParams}}{{^hasOptionalParams}}{{#hasParams}}, {{/hasParams}}{Options{{#nullSafe}}?{{/nullSafe}} options}{{/hasOptionalParams}}) async {
 
@@ -48,7 +53,12 @@ part of {{pubName}}.api;
         throw ApiException(500, 'Received an empty body');
         }
 
+    {{#vendorExtensions.x-dart-produces-raw}}
+      return response;
+    {{/vendorExtensions.x-dart-produces-raw}}
+    {{^vendorExtensions.x-dart-produces-raw}}
         return await apiDelegate.{{nickname}}_decode({{#nullSafe}}body{{/nullSafe}}{{^nullSafe}}response{{/nullSafe}});
+    {{/vendorExtensions.x-dart-produces-raw}}
     {{/returnType}}
       }
 
@@ -203,6 +213,7 @@ part of {{pubName}}.api;
       return await apiClient.invokeAPI(__path, queryParams, {{#hasFormParams}}postBody{{/hasFormParams}}{{#bodyParam}}postBody{{/bodyParam}}{{^bodyParam}}{{^hasFormParams}}null{{/hasFormParams}}{{/bodyParam}}, authNames, opt);
       }
 
+    {{^vendorExtensions.x-dart-produces-raw}}
     {{#vendorExtensions.x-dart-produces-json}}
       {{#returnType}}Future<{{{returnType}}}> {{/returnType}}{{^returnType}}Future<void> {{/returnType}}
     {{/vendorExtensions.x-dart-produces-json}}
@@ -224,15 +235,24 @@ part of {{pubName}}.api;
         {{/isMap}}
         {{^isMap}}
           {{#returnType}}
+            {{#vendorExtensions.x-dart-produces-raw}}
+                return response;
+            {{/vendorExtensions.x-dart-produces-raw}}
+            {{^vendorExtensions.x-dart-produces-raw}}
               return LocalApiClient.deserializeFromString(await utf8.decodeStream({{#nullSafe}}body{{/nullSafe}}{{^nullSafe}}response.body{{/nullSafe}}), '{{{returnType}}}') as {{{returnType}}};
+            {{/vendorExtensions.x-dart-produces-raw}}
           {{/returnType}}
         {{/isMap}}
       {{/isArray}}
     {{/vendorExtensions.x-dart-produces-json}}
     {{^vendorExtensions.x-dart-produces-json}}
+        {{^vendorExtensions.x-dart-produces-raw}}
         return await utf8.decodeStream({{#nullSafe}}body{{/nullSafe}}{{^nullSafe}}response.body{{/nullSafe}});
+        {{/vendorExtensions.x-dart-produces-raw}}
     {{/vendorExtensions.x-dart-produces-json}}
       }
+    {{/vendorExtensions.x-dart-produces-raw}}
+
   {{/operation}}
     }
 


### PR DESCRIPTION
Introduce extra code in api generation to ensure that
octet streams are not treated as multipart files and
they are always passed out as ApiResponses. This will
have side effects for files we send as well, but there
is currently no good solution for this.

Fixes issue #35