### PR TITLE
Fixed generating value assignment in toJson() for dynamic fields

### DIFF
--- a/src/it/k8s_null/test.yaml
+++ b/src/it/k8s_null/test.yaml
@@ -593,3 +593,17 @@ components:
             items:
               type: number
               format: double
+    PatchDocument:
+      type: object
+      properties:
+        value:
+          nullable: true
+        path:
+          type: string
+          nullable: true
+        op:
+          type: string
+          nullable: true
+        from:
+          type: string
+          nullable: true

--- a/src/main/resources/dart2-v3template/class.mustache
+++ b/src/main/resources/dart2-v3template/class.mustache
@@ -109,6 +109,9 @@ class {{classname}}{{#parent}} extends {{parent}}{{/parent}} {
         {{#isPrimitiveType}}
           json[r'{{baseName}}'] = {{{name}}};
         {{/isPrimitiveType}}
+        {{#isAnyType}}
+          json[r'{{baseName}}'] = {{{name}}};
+        {{/isAnyType}}
       {{/items}}
       {{^required}}
     } {{#generateNullValuesToJson}}else {


### PR DESCRIPTION
I believe this is another issue caused by update of core library. When a field doesn't have a type specified in docs, it gets an empty if statement in `toJson()` method instead of key-value assignment to the map.