### PR TITLE
Fix for #88 

### DIFF
--- a/src/main/resources/dart2-v3template/class.mustache
+++ b/src/main/resources/dart2-v3template/class.mustache
@@ -78,7 +78,8 @@ class {{{classname}}}{{#parent}} extends {{parent}}{{/parent}} {
             final _jsonData = json[r'{{{baseName}}}'];
             if (_jsonData == null) {
               {{#required}}
-              {{> _deserialisation_error }}
+                {{#defaultValue}} return {{{defaultValue}}};{{/defaultValue}}
+                {{^defaultValue}}{{> _deserialisation_error }}{{/defaultValue}}
               {{/required}}
               {{^required}}
                 {{#defaultValue}} return {{{defaultValue}}};{{/defaultValue}}


### PR DESCRIPTION
If any variable is marked required in yaml and have a default value, but we get deserialization error when the json doesn't have the    data for that variable.   