### PR TITLE
_complex_from_json_required handle the null, so remove double checking for null in generated code

### DIFF
--- a/src/main/resources/dart2-v3template/class.mustache
+++ b/src/main/resources/dart2-v3template/class.mustache
@@ -85,19 +85,21 @@ class {{{classname}}}{{#parent}} extends {{parent}}{{/parent}} {
       {{^vendorExtensions.x-var-is-binary}}
           {{^isNullable}}
             final _jsonData = json[r'{{{baseName}}}'];
-            if (_jsonData == null) {
-              {{#required}}
-                {{#defaultValue}} return {{{defaultValue}}};{{/defaultValue}}
-                {{^defaultValue}}{{> _deserialisation_error }}{{/defaultValue}}
-              {{/required}}
-              {{^required}}
-                {{#defaultValue}} return {{{defaultValue}}};{{/defaultValue}}
-                {{^defaultValue}}{{> _deserialisation_error }}{{/defaultValue}}
-              {{/required}}
-            }
+            {{#defaultValue}}
+              if (_jsonData == null) {
+                  return {{{defaultValue}}};
+              }
+            {{/defaultValue}}
             {{#isArray}}{{>_complex_from_json_required}}{{/isArray}}
             {{#isMap}}{{>_complex_from_json_required}}{{/isMap}}
-            {{^items}}{{>_simple_from_json_required}}{{/items}}
+            {{^items}}
+              {{^defaultValue}}
+                if (_jsonData == null) {
+                  {{> _deserialisation_error }}
+                }
+              {{/defaultValue}}
+              {{>_simple_from_json_required}}
+            {{/items}}
           {{/isNullable}}
 
           {{#isNullable}}


### PR DESCRIPTION


**Generated code :**

```
  static List<String> fromJson_tags(Map<String, dynamic> json) {
    final _jsonData = json[r'tags'];
    if (_jsonData == null) {
      throw DeserialisationError(json, r'tags', r'',
          'tags field is null and is required to have a value');
    }
    return (_jsonData == null)
        ? []
        : ((dynamic data) {
            return (data as List<dynamic>).cast<String>();
          }(_jsonData));
  }

```

**Expected code:** 
```
  static List<String> fromJson_tags(Map<String, dynamic> json) {
    final _jsonData = json[r'tags'];
    return (_jsonData == null)
        ? []
        : ((dynamic data) {
            return (data as List<dynamic>).cast<String>();
          }(_jsonData));
  }
```